### PR TITLE
better support for ubuntu 20.04

### DIFF
--- a/cloud-init-ansible-roles.yml.tmpl
+++ b/cloud-init-ansible-roles.yml.tmpl
@@ -3,8 +3,9 @@
 
 # requisites
 apt_upgrade: true
-apt_sources:
-  - source: ppa:ansible/ansible
+# uncomment to support 18.04
+#apt_sources:
+#  - source: ppa:ansible/ansible
 packages:
   - ansible
 

--- a/postinstall-script-template.sh
+++ b/postinstall-script-template.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-CLOUD_INIT_TMPL="https://raw.githubusercontent.com/cloudcall-fr/cloud-init-ansible/v1.1.0/cloud-init-ansible-roles.yml.tmpl"
+CLOUD_INIT_TMPL="https://raw.githubusercontent.com/cloudcall-fr/cloud-init-ansible/v1.1.0-20.04-preview/cloud-init-ansible-roles.yml.tmpl"
 
 set +a
 FILE=.env


### PR DESCRIPTION
The ansible ppa is the recommended installation source on ubuntu 18.04, but generates python errors during installation on 20.04

Fetching from upstream is preferable